### PR TITLE
Remove FezGame.Tools.ErrorDialog type

### DIFF
--- a/Stripper.cs
+++ b/Stripper.cs
@@ -15,6 +15,7 @@ namespace FEZStripGen
             RemoveUncommonTypes(module, new[]{
                 "FezGame.Components.MockAchievement",
                 "FezGame.Services.MockUser",
+                "FezGame.Tools.ErrorDialog",
             });
         }
 


### PR DESCRIPTION
When running MonoMod on the DRM free Linux version of FEZ, it complains about not being able to find this ErrorDialog. This PR adds that to the list of items to strip. This successfully allows MonoMod to patch FEZ.exe on Linux. I also tested on Windows and didn't find any regressions.